### PR TITLE
Fix all mailing list and partial date load errors

### DIFF
--- a/1-raw-data/gcs/gcs.go
+++ b/1-raw-data/gcs/gcs.go
@@ -166,7 +166,6 @@ func (gcs *StorageConnection) StoreContentInBucket(ctx context.Context, fileName
 		err = fmt.Errorf("%w: %v", storageCtxCloseErr, err)
 		return
 	}
-
 	return
 }
 

--- a/1-raw-data/mailinglists/googlegroups/googlegroups_data_test.go
+++ b/1-raw-data/mailinglists/googlegroups/googlegroups_data_test.go
@@ -61,7 +61,7 @@ func TestHttpStringResponse(t *testing.T) {
 func TestGetFileDate(t *testing.T) {
 	var (
 		gotDate time.Time
-		gotErr error
+		gotErr  error
 	)
 
 	wantDateKeyOneTwo, _ := utils.GetDateTimeType("1991-01-29")
@@ -72,7 +72,7 @@ func TestGetFileDate(t *testing.T) {
 	tests := []struct {
 		comparisonType string
 		matchDate      string
-		wantFileDate  time.Time
+		wantFileDate   time.Time
 		wantErr        error
 	}{
 		{
@@ -244,9 +244,9 @@ func TestTopicIDToRawMsgUrlMap(t *testing.T) {
 	exTopicIdDomDate, _ := utils.FakeHttpDomResponse("topicIDToRawMsgUrlMapDate")
 	exAbuseHiddenMsg, _ := utils.FakeHttpDomResponse("abuseHiddenMsg")
 	startDateTimeIdsTime, _ := utils.GetDateTimeType(now.Format("2006-01-02"))
-	endDateTimeIdsTime , _ := utils.GetDateTimeType(now.Format("2006-01-02"))
+	endDateTimeIdsTime, _ := utils.GetDateTimeType(now.Format("2006-01-02"))
 	startDateTimeIdsDate, _ := utils.GetDateTimeType("2018-09-01")
-	endDateTimeIdsDate , _ := utils.GetDateTimeType("2018-09-30")
+	endDateTimeIdsDate, _ := utils.GetDateTimeType("2018-09-30")
 
 	var (
 		gotRawMsgURLMap map[string][]string
@@ -256,8 +256,8 @@ func TestTopicIDToRawMsgUrlMap(t *testing.T) {
 		comparisonType   string
 		org              string
 		groupName        string
-		startDateTime time.Time
-		endDateTime time.Time
+		startDateTime    time.Time
+		endDateTime      time.Time
 		dom              *goquery.Document
 		wantRawMsgURLMap map[string][]string
 		wantErr          error
@@ -266,8 +266,8 @@ func TestTopicIDToRawMsgUrlMap(t *testing.T) {
 			comparisonType: "Pull topic ids for time",
 			org:            "",
 			groupName:      "golang-checkins",
-			startDateTime: startDateTimeIdsTime,
-			endDateTime: endDateTimeIdsTime,
+			startDateTime:  startDateTimeIdsTime,
+			endDateTime:    endDateTimeIdsTime,
 			dom:            exTopicIdDomTime,
 			wantRawMsgURLMap: map[string][]string{
 				fmt.Sprintf("%4d-%02d.txt", timeYearCheck, timeMonthCheck): []string{"https://groups.google.com/forum/message/raw?msg=golang-checkins/8sv65_WCOS4/3Fc-diD_AwAJ"}},
@@ -277,8 +277,8 @@ func TestTopicIDToRawMsgUrlMap(t *testing.T) {
 			comparisonType: "Pull topic ids for date",
 			org:            "",
 			groupName:      "golang-checkins",
-			startDateTime: startDateTimeIdsDate,
-			endDateTime: endDateTimeIdsDate,
+			startDateTime:  startDateTimeIdsDate,
+			endDateTime:    endDateTimeIdsDate,
 			dom:            exTopicIdDomDate,
 			wantRawMsgURLMap: map[string][]string{
 				"2018-09.txt": []string{"https://groups.google.com/forum/message/raw?msg=golang-checkins/8sv65_WCOS4/3Fc-diD_AwAJ"}},
@@ -308,7 +308,7 @@ func TestTopicIDToRawMsgUrlMap(t *testing.T) {
 
 // TODO verify the temp map is needed
 func TestGetRawMsgURLWorker(t *testing.T) {
-	var 		startDateTime, endDateTime time.Time
+	var startDateTime, endDateTime time.Time
 
 	tests := []struct {
 		comparisonType string
@@ -351,7 +351,7 @@ func TestGetRawMsgURLWorker(t *testing.T) {
 }
 
 func TestListRawMsgURLsByMonth(t *testing.T) {
-	var 		startDateTime, endDateTime time.Time
+	var startDateTime, endDateTime time.Time
 	rawMsg100 := map[string][]string{"1893-01.txt": []string{"https://en.wikipedia.org/wiki/Lili%CA%BBuokalani"}}
 	for i := 0; i < 100; i++ {
 		rawMsg100["1893-01.txt"] = append(rawMsg100["1893-01.txt"], "https://en.wikipedia.org/wiki/Lili%CA%BBuokalani")
@@ -369,6 +369,7 @@ func TestListRawMsgURLsByMonth(t *testing.T) {
 		worker           int
 		httpToDom        utils.HttpDomResponse
 		topicToMsgMap    TopicIDToRawMsgUrlMap
+		allDateRun       bool
 		wantRawMsgURLMap map[string][]string
 		wantErr          error
 	}{
@@ -379,6 +380,7 @@ func TestListRawMsgURLsByMonth(t *testing.T) {
 			worker:           1,
 			httpToDom:        utils.FakeHttpDomResponse,
 			topicToMsgMap:    utils.FakeTopicIDToRawMsgUrlMap,
+			allDateRun:       true,
 			wantRawMsgURLMap: rawMsg100,
 			wantErr:          nil,
 		},
@@ -389,13 +391,14 @@ func TestListRawMsgURLsByMonth(t *testing.T) {
 			worker:           1,
 			httpToDom:        utils.FakeHttpDomResponse,
 			topicToMsgMap:    utils.FakeTopicIDToRawMsgUrlMap,
+			allDateRun:       true,
 			wantRawMsgURLMap: map[string][]string{"1893-01.txt": []string{"https://en.wikipedia.org/wiki/Lili%CA%BBuokalani"}},
 			wantErr:          nil,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.comparisonType, func(t *testing.T) {
-			if gotRawMsgURLMap, gotErr = listRawMsgURLsByMonth(test.org, test.groupName, startDateTime, endDateTime , test.worker, test.httpToDom, test.topicToMsgMap); !errors.Is(gotErr, test.wantErr) {
+			if gotRawMsgURLMap, gotErr = listRawMsgURLsByMonth(test.org, test.groupName, startDateTime, endDateTime, test.worker, test.httpToDom, test.topicToMsgMap, test.allDateRun); !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("Error response does not match.\n got: %v\nwant: %v", gotErr, test.wantErr)
 			}
 			if !reflect.DeepEqual(gotRawMsgURLMap, test.wantRawMsgURLMap) {

--- a/1-raw-data/mailinglists/mailman/mailman_data.go
+++ b/1-raw-data/mailinglists/mailman/mailman_data.go
@@ -62,7 +62,7 @@ func GetMailmanData(ctx context.Context, storage gcs.Connection, groupName, star
 
 	orgEndDate := endDateResult
 
-	// If the date range is larger than one month, cycle and capture content by month
+	// Cycle and capture content by month
 	for startDateResult <= orgEndDate {
 		// Break dates out to span only a month, start must be 1st and end must be 1st of the following month unless today
 		if startDateResult, endDateResult, err = utils.SplitDatesByMonth(startDateResult, endDateResult, numMonths); err != nil {
@@ -77,8 +77,10 @@ func GetMailmanData(ctx context.Context, storage gcs.Connection, groupName, star
 
 		startDateTime, _ = utils.GetDateTimeType(startDateResult)
 		startDateResult = startDateTime.AddDate(0, 1, 0).Format("2006-01-02")
+		//startDateResult = utils.AddMonth(startDateTime).Format("2006-01-02")
 		endDateTime, _ = utils.GetDateTimeType(endDateResult)
 		endDateResult = endDateTime.AddDate(0, 1, 0).Format("2006-01-02")
+		print("MAILMAN", startDateResult, endDateResult)
 	}
 
 	if endDateResult < orgEndDate {

--- a/1-raw-data/mailinglists/main.go
+++ b/1-raw-data/mailinglists/main.go
@@ -126,7 +126,7 @@ func main() {
 					//startDateResult = now.AddDate(0, -1, 0).Format("2006-01-02")
 					//endDateResult = now.Format("2006-01-02")
 				}
-				log.Printf("Working on mailinglist: ", subName)
+				log.Printf("Working on mailinglist: %s", subName)
 
 				//Get mailing list data and store
 				getData(ctx, &storageConn, httpToDom, *workerNum, numMonths, *mailingList, groupName, startDateResult, endDateResult, *allDateRun)

--- a/1-raw-data/mailinglists/main.go
+++ b/1-raw-data/mailinglists/main.go
@@ -21,7 +21,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -47,24 +46,22 @@ var (
 	groupNames   = flag.String("groupname", "", "Mailing list group name. Enter 1 or more and use spaces to identify. CAUTION also enter the buckets to load to in the same order.")
 	startDate    = flag.String("start-date", "", "Start date in format of year-month-date and 4dig-2dig-2dig.")
 	endDate      = flag.String("end-date", "", "End date in format of year-month-date and 4dig-2dig-2dig.")
-	workerNum    = flag.Int("workers", 1, "Number of workers to use for goroutines.")
+	workerNum    = flag.Int("workers", 20, "Number of workers to use for goroutines.")
 	subNames     []string
 )
 
-func getData(ctx context.Context, storage gcs.Connection, httpToDom utils.HttpDomResponse, workerNum, numMonths int, mailingList, groupName, startDateString, endDateString string) {
+func getData(ctx context.Context, storage gcs.Connection, httpToDom utils.HttpDomResponse, workerNum, numMonths int, mailingList, groupName, startDateString, endDateString string, allDateRun bool) {
 	switch mailingList {
-	//TODO add start and end dates to pipermail
 	case "pipermail":
 		if err := pipermail.GetPipermailData(ctx, storage, groupName, startDateString, endDateString, httpToDom); err != nil {
-			log.Fatalf("Mailman load failed: %v", err)
+			log.Fatalf("Pipermail load failed: %v", err)
 		}
 	case "mailman":
 		if err := mailman.GetMailmanData(ctx, storage, groupName, startDateString, endDateString, numMonths); err != nil {
 			log.Fatalf("Mailman load failed: %v", err)
 		}
-		//TODO add start and end dates to google groups
 	case "gg":
-		if err := googlegroups.GetGoogleGroupsData(ctx, "", groupName, startDateString, endDateString, storage, workerNum); err != nil {
+		if err := googlegroups.GetGoogleGroupsData(ctx, "", groupName, startDateString, endDateString, storage, workerNum, allDateRun); err != nil {
 			log.Fatalf("GoogleGroups load failed: %v", err)
 		}
 	default:
@@ -77,7 +74,7 @@ func main() {
 	numMonths := 1
 	httpToDom := utils.DomResponse
 	flag.Parse()
-	fmt.Printf(*projectID)
+	//log.Printf("PROJECTID", *projectID)
 
 	//Setup Storage connection
 	ctx, cancel := context.WithCancel(context.Background())
@@ -105,7 +102,7 @@ func main() {
 		// Run Build to load all mailing lists
 		if *allListRun {
 			log.Printf("Build all lists ")
-			mailListMap := map[string]string{"gg-angular": "2009-09-01", "gg-golang-announce": "2011-05-01", "gg-golang-checkins": "2009-11-01", " gg-golang-codereviews": "2013-12-01", "gg-golang-dev": "2009-11-01", "gg-golang-nuts": "2009-11-01", "gg-nodejs": "2009-06-01", "mailman-python-announce-list": "1999-04-01", "mailman-python-dev": "1999-04-01", "mailman-python-ideas": "2006-12-01", "pipermail-python-announce-list": "1999-04-01", "pipermail-python-dev": "1995-03-01", "pipermail-python-ideas": "2006-12-01", "pipermail-python-list": "1999-02-01"}
+			mailListMap := map[string]string{"gg-angular": "2009-09-01", "gg-golang-announce": "2011-05-01", "gg-golang-checkins": "2009-11-01", "gg-golang-codereviews": "2013-12-01", "gg-golang-dev": "2009-11-01", "gg-golang-nuts": "2009-11-01", "gg-nodejs": "2009-06-01", "mailman-python-announce-list": "1999-04-01", "mailman-python-dev": "1999-04-01", "mailman-python-ideas": "2006-12-01", "pipermail-python-announce-list": "1999-04-01", "pipermail-python-dev": "1995-03-01", "pipermail-python-ideas": "2006-12-01", "pipermail-python-list": "1999-02-01"}
 
 			for subName, origStartDate := range mailListMap {
 				startDateResult, endDateResult := "", ""
@@ -125,13 +122,16 @@ func main() {
 					if startDateResult, endDateResult, err = utils.SplitDatesByMonth(*startDate, *endDate, 1); err != nil {
 						log.Fatalf("Date error: %v", err)
 					}
-					log.Printf("One Month Run All MailingLists")
-					startDateResult = now.AddDate(0, -1, 0).Format("2006-01-02")
-					endDateResult = now.Format("2006-01-02")
+					//log.Printf("One Month Run All MailingLists")
+					//startDateResult = now.AddDate(0, -1, 0).Format("2006-01-02")
+					//endDateResult = now.Format("2006-01-02")
 				}
+				log.Printf("Working on mailinglist: ", subName)
 
 				//Get mailing list data and store
-				getData(ctx, &storageConn, httpToDom, *workerNum, numMonths, *mailingList, groupName, startDateResult, endDateResult)
+				getData(ctx, &storageConn, httpToDom, *workerNum, numMonths, *mailingList, groupName, startDateResult, endDateResult, *allDateRun)
+
+				log.Printf("After get data ")
 			}
 		} else {
 			log.Printf("Build test run with mailman")
@@ -164,7 +164,7 @@ func main() {
 			}
 
 			//Get mailing list data and store
-			getData(ctx, &storageConn, httpToDom, *workerNum, numMonths, *mailingList, groupName, *startDate, *endDate)
+			getData(ctx, &storageConn, httpToDom, *workerNum, numMonths, *mailingList, groupName, *startDate, *endDate, *allDateRun)
 		}
 	}
 }

--- a/1-raw-data/mailinglists/pipermail/pipermail_data.go
+++ b/1-raw-data/mailinglists/pipermail/pipermail_data.go
@@ -51,6 +51,7 @@ func changeMonthToDigit(fileName string) (newName string, fileDate time.Time) {
 // Get, parse and store Pipermail data in GCS.
 func GetPipermailData(ctx context.Context, storage gcs.Connection, groupName, startDateString, endDateString string, httpToDom utils.HttpDomResponse) (storeErr error) {
 	mailingListURL := fmt.Sprintf("https://mail.python.org/pipermail/%s/", groupName)
+	log.Printf("PIPERMAIL loading")
 
 	var (
 		dom                        *goquery.Document
@@ -82,10 +83,7 @@ func GetPipermailData(ctx context.Context, storage gcs.Connection, groupName, st
 							// Each func interface doesn't allow passing errors?
 							storeErr = fmt.Errorf("%w: %v", StorageErr, err)
 						}
-					} else {
-						log.Printf("File %s not stored because date %s outside timespan %s - %s", filename, fileDate, startDateString, endDateString)
 					}
-
 				}
 			}
 		}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 steps:
-# Initial exploration esp with variables
+# All list and partial dates run
 - name: 'ubuntu'
   env:
     - 'PROJECT_ID=$PROJECT_ID'
 - name: golang
-  args: ['go', 'run', '1-raw-data/mailinglists/main.go', '-build-list-run', '-all-list-run', 'start-date=2021-01-01', 'end-date=2021-01-31', '-project-id=$PROJECT_ID']
+  args: ['go', 'run', '1-raw-data/mailinglists/main.go', '-build-list-run', '-all-list-run', '-start-date=2021-01-01', '-end-date=2021-01-31', '-project-id=$PROJECT_ID']
+
 
 #Test Run
 #- name: golang


### PR DESCRIPTION
Fix errors with getting all mailing list and partial date load to run.  

- One issue from previous PR was - was missing on a couple parameters in build
- Fixed how dates are set so that it stays in the current start month if the timespan is large enough
- Fixed related tests
- Added comments to help clarify what the code is doing as well as to 
- Fixed google groups load so that it doesn't look at all the emails if we are not going for all the dates | its a hacky solution that needs to be revisited because it takes the first 15% of the total pages available. This is assuming if you are not loading all dates, you are loading a more recent history of dates but if you enter start and end that is further in history, it is not setup to appropriately catch this.
- Added default workerNum otherwise it freezes 

- There is an error still for : connection reset by peer that I think is there are too many requests to the google groups server and potentially a lower worker num will help.

